### PR TITLE
[screensaver.pyro] 3.1.0

### DIFF
--- a/screensaver.pyro/addon.xml.in
+++ b/screensaver.pyro/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.pyro"
-  version="3.0.0"
+  version="3.1.0"
   name="Pyro"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required